### PR TITLE
Fix install method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@ This is a command line interface under heavy development for [Backyards](https:/
 
 ### Installation
 
-```bash
-❯ go get github.com/banzaicloud/backyards-cli/cmd/backyards
-```
+Pre-built binaries are available in multiple package formats. Download the [latest release](https://github.com/banzaicloud/backyards-cli/releases).
 
 ### Use
 


### PR DESCRIPTION
`go get` is not working currently because of go mod replacements.
