### PR TITLE
Show descriptive message about the caveats and print the wrapped token in the login command

### DIFF
--- a/internal/cli/cmd/login/cmd.go
+++ b/internal/cli/cmd/login/cmd.go
@@ -54,7 +54,11 @@ func NewLoginCmd(cli cli.CLI) *cobra.Command {
 				}
 			}
 			err = Login(cli, func(body *auth.ResponseBody) {
-				logrus.Infof("Login token: %s", body.User.WrappedToken)
+				if cli.InteractiveTerminal() {
+					logrus.Infof("Login token: %s", body.User.WrappedToken)
+				} else {
+					fmt.Println(body.User.WrappedToken)
+				}
 			})
 			return err
 		},

--- a/internal/cli/cmd/login/cmd.go
+++ b/internal/cli/cmd/login/cmd.go
@@ -100,10 +100,9 @@ func Login(cli cli.CLI, onAuth func(*auth.ResponseBody)) error {
 		if onAuth != nil {
 			onAuth(authInfo)
 		}
-	} else {
-		if cli.InteractiveTerminal() {
-			logrus.Debug("Backyards authentication is disabled")
-		}
+	}
+	if cli.InteractiveTerminal() {
+		logrus.Debug("Backyards authentication is disabled")
 	}
 	return nil
 }

--- a/internal/cli/cmd/login/cmd.go
+++ b/internal/cli/cmd/login/cmd.go
@@ -92,14 +92,18 @@ func Login(cli cli.CLI, onAuth func(*auth.ResponseBody)) error {
 		}
 	}
 	if authInfo != nil {
-		logrus.Infof("Logged in as %s", authInfo.User.Name)
-		logrus.Debugf("Token: %s", authInfo.User.Token)
-		logrus.Debugf("Wrapped token: %s", authInfo.User.WrappedToken)
+		if cli.InteractiveTerminal() {
+			logrus.Infof("Logged in as %s", authInfo.User.Name)
+			logrus.Debugf("Token: %s", authInfo.User.Token)
+			logrus.Debugf("Wrapped token: %s", authInfo.User.WrappedToken)
+		}
 		if onAuth != nil {
 			onAuth(authInfo)
 		}
 	} else {
-		logrus.Debug("Backyards authentication is disabled")
+		if cli.InteractiveTerminal() {
+			logrus.Debug("Backyards authentication is disabled")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
Display the wrapped token in the login command and show a descriptive message to the user to make sure they understand the limitations.

### Why?
Because the login component on the UI will only accept the wrapped token starting from the next release.

### Additional context
The `-v` flag can be used to show the nested JWT token as well, but that is for the CLI or programmatic use cases.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
