### PR TITLE
Install flags, error handling improvements, login mutex

### DIFF
--- a/cmd/docs/backyards_install.md
+++ b/cmd/docs/backyards_install.md
@@ -33,14 +33,10 @@ backyards install [flags]
   -d, --dump-resources           Dump resources to stdout instead of applying them
       --enable-auditsink         Enable deploying the auditsink service and sending audit logs over http
   -h, --help                     help for install
-      --install-canary           Install Canary feature as well
-      --install-cert-manager     Install cert-manager as well
-      --install-demoapp          Install Demo application as well
-  -a, --install-everything       Install every component at once
-      --install-istio            Install Istio mesh as well
+  -a, --install-everything       Install all required components at once
       --istio-namespace string   Namespace of Istio sidecar injector (default "istio-system")
       --release-name string      Name of the release (default "backyards")
-      --run-demo                 Send load to demo application and opens up dashboard
+      --run-demo                 Install demo application, send load and open up the dashboard
       --web-image string         Image for the frontend
 ```
 

--- a/cmd/docs/backyards_uninstall.md
+++ b/cmd/docs/backyards_uninstall.md
@@ -30,11 +30,7 @@ backyards uninstall [flags]
   -h, --help                     help for uninstall
       --istio-namespace string   Namespace of Istio sidecar injector (default "istio-system")
       --release-name string      Name of the release (default "backyards")
-      --uninstall-canary         Uninstall Canary feature as well
-      --uninstall-cert-manager   Uninstall cert-manager as well
-      --uninstall-demoapp        Uninstall Demo application as well
-  -a, --uninstall-everything     Uninstall every component at once
-      --uninstall-istio          Uninstall Istio mesh as well
+  -a, --uninstall-everything     Uninstall all components at once
 ```
 
 ### Options inherited from parent commands

--- a/internal/cli/cmd/common/common.go
+++ b/internal/cli/cmd/common/common.go
@@ -26,7 +26,6 @@ func GetGraphQLClient(cli cli.CLI) (graphql.Client, error) {
 	if token == "" {
 		err := login.Login(cli, func(body *auth.Credentials) {
 			token = body.User.Token
-			cli.GetPersistentConfig().SetToken(token)
 		})
 		if err != nil {
 			return nil, err

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -69,8 +69,6 @@ type InstallOptions struct {
 	istioNamespace string
 	dumpResources  bool
 
-	installDemoapp    bool
-	installIstio      bool
 	enableAuditSink   bool
 	anonymousAuth     bool
 	installEverything bool

--- a/internal/cli/cmd/uninstall.go
+++ b/internal/cli/cmd/uninstall.go
@@ -76,12 +76,7 @@ It can only dump the removable resources with the '--dump-resources' option.`,
 			)
 
 			return cli.IfConfirmed("Uninstall Backyards. This command will destroy resources and cannot be undone. Are you sure to proceed?", func() error {
-				if cli.InteractiveTerminal() &&
-					!(options.uninstallEverything ||
-						options.uninstallCertManager ||
-						options.uninstallCanary ||
-						options.uninstallDemoapp ||
-						options.uninstallIstio) {
+				if cli.InteractiveTerminal() && !options.uninstallEverything {
 					var response string
 					fmt.Fprintln(cli.Out(), heredoc.Doc(`
 						Do you want to remove all resources deployed by the CLI, or just the Backyards component?
@@ -110,11 +105,7 @@ It can only dump the removable resources with the '--dump-resources' option.`,
 	cmd.Flags().StringVar(&options.istioNamespace, "istio-namespace", "istio-system", "Namespace of Istio sidecar injector")
 	cmd.Flags().BoolVarP(&options.dumpResources, "dump-resources", "d", false, "Dump resources to stdout instead of applying them")
 
-	cmd.Flags().BoolVar(&options.uninstallCanary, "uninstall-canary", false, "Uninstall Canary feature as well")
-	cmd.Flags().BoolVar(&options.uninstallDemoapp, "uninstall-demoapp", false, "Uninstall Demo application as well")
-	cmd.Flags().BoolVar(&options.uninstallIstio, "uninstall-istio", false, "Uninstall Istio mesh as well")
-	cmd.Flags().BoolVar(&options.uninstallCertManager, "uninstall-cert-manager", false, "Uninstall cert-manager as well")
-	cmd.Flags().BoolVarP(&options.uninstallEverything, "uninstall-everything", "a", false, "Uninstall every component at once")
+	cmd.Flags().BoolVarP(&options.uninstallEverything, "uninstall-everything", "a", false, "Uninstall all components at once")
 
 	return cmd
 }
@@ -163,7 +154,7 @@ func (c *uninstallCommand) runSubcommands(cli cli.CLI, options *UninstallOptions
 	var err error
 	var scmd *cobra.Command
 
-	if options.uninstallDemoapp || options.uninstallEverything {
+	if options.uninstallEverything {
 		scmdOptions := demoapp.NewUninstallOptions()
 		if options.dumpResources {
 			scmdOptions.DumpResources = true
@@ -178,7 +169,7 @@ func (c *uninstallCommand) runSubcommands(cli cli.CLI, options *UninstallOptions
 		}
 	}
 
-	if options.uninstallCanary || options.uninstallEverything {
+	if options.uninstallEverything {
 		scmdOptions := canary.NewUninstallOptions()
 		if options.dumpResources {
 			scmdOptions.DumpResources = true
@@ -193,7 +184,7 @@ func (c *uninstallCommand) runSubcommands(cli cli.CLI, options *UninstallOptions
 		}
 	}
 
-	if options.uninstallCertManager || options.uninstallEverything {
+	if options.uninstallEverything {
 		scmdOptions := certmanager.NewUninstallOptions()
 		if options.dumpResources {
 			scmdOptions.DumpResources = true
@@ -208,7 +199,7 @@ func (c *uninstallCommand) runSubcommands(cli cli.CLI, options *UninstallOptions
 		}
 	}
 
-	if options.uninstallIstio || options.uninstallEverything {
+	if options.uninstallEverything {
 		scmdOptions := istio.NewUninstallOptions()
 		if options.dumpResources {
 			scmdOptions.DumpResources = true

--- a/internal/cli/cmd/uninstall.go
+++ b/internal/cli/cmd/uninstall.go
@@ -41,11 +41,7 @@ type UninstallOptions struct {
 	istioNamespace string
 	dumpResources  bool
 
-	uninstallCanary      bool
-	uninstallDemoapp     bool
-	uninstallIstio       bool
-	uninstallCertManager bool
-	uninstallEverything  bool
+	uninstallEverything bool
 }
 
 func NewUninstallCommand(cli cli.CLI) *cobra.Command {

--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -103,7 +103,6 @@ func getAPIVersion(cli cli.CLI, versionEndpoint string) string {
 	if token == "" {
 		err = login.Login(cli, func(authInfo *auth.Credentials) {
 			token = authInfo.User.Token
-			cli.GetPersistentConfig().SetToken(authInfo.User.Token)
 		})
 		if err != nil {
 			if logrus.IsLevelEnabled(logrus.DebugLevel) {

--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -92,7 +92,9 @@ func (c *versionCommand) run(cli cli.CLI, options *versionOptions) {
 func getAPIVersion(cli cli.CLI, versionEndpoint string) string {
 	endpoint, err := cli.InitializedEndpoint()
 	if err != nil {
-		logrus.Error(err)
+		if logrus.IsLevelEnabled(logrus.DebugLevel) {
+			logrus.Errorf("%+v", err)
+		}
 		return defaultVersionString
 	}
 	defer endpoint.Close()
@@ -104,7 +106,9 @@ func getAPIVersion(cli cli.CLI, versionEndpoint string) string {
 			cli.GetPersistentConfig().SetToken(authInfo.User.Token)
 		})
 		if err != nil {
-			logrus.Error(err)
+			if logrus.IsLevelEnabled(logrus.DebugLevel) {
+				logrus.Errorf("%+v", err)
+			}
 			return defaultVersionString
 		}
 	}
@@ -113,7 +117,9 @@ func getAPIVersion(cli cli.CLI, versionEndpoint string) string {
 
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		logrus.Error(err)
+		if logrus.IsLevelEnabled(logrus.DebugLevel) {
+			logrus.Errorf("%+v", err)
+		}
 		return defaultVersionString
 	}
 	if token != "" {
@@ -123,7 +129,9 @@ func getAPIVersion(cli cli.CLI, versionEndpoint string) string {
 	// nolint G107
 	resp, err := endpoint.HTTPClient().Do(request)
 	if err != nil {
-		logrus.Error(err)
+		if logrus.IsLevelEnabled(logrus.DebugLevel) {
+			logrus.Errorf("%+v", err)
+		}
 		return defaultVersionString
 	}
 	defer resp.Body.Close()
@@ -132,12 +140,16 @@ func getAPIVersion(cli cli.CLI, versionEndpoint string) string {
 	decoder := json.NewDecoder(resp.Body)
 	err = decoder.Decode(&bi)
 	if err != nil {
-		logrus.Error(err)
+		if logrus.IsLevelEnabled(logrus.DebugLevel) {
+			logrus.Errorf("%+v", err)
+		}
 		return defaultVersionString
 	}
 
 	if resp.StatusCode != 200 {
-		logrus.Errorf("Request failed: %s", resp.Status)
+		if logrus.IsLevelEnabled(logrus.DebugLevel) {
+			logrus.Errorf("Request failed: %s", resp.Status)
+		}
 		return defaultVersionString
 	}
 

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -93,7 +93,7 @@ func (c *client) Login() (*Credentials, error) {
 		}
 		err = json.NewDecoder(bytes.NewBuffer(responseBody)).Decode(parsedResponse)
 		if err != nil {
-			return nil, errors.WrapWithDetails(err, "failed to decode response", "response", string(responseBody))
+			return nil, errors.WrapWithDetails(err, "invalid response", "response", string(responseBody))
 		}
 		if response.StatusCode < 500 {
 			if parsedResponse.ErrorCode == servererror.AuthDisabledErrorCode {
@@ -111,7 +111,7 @@ func (c *client) Login() (*Credentials, error) {
 	}
 	err = json.NewDecoder(bytes.NewBuffer(responseBody)).Decode(parsedResponse)
 	if err != nil {
-		return parsedResponse, errors.WrapWithDetails(err, "failed to decode response", "response", string(responseBody))
+		return parsedResponse, errors.WrapWithDetails(err, "invalid response", "response", string(responseBody))
 	}
 	if parsedResponse.User.Name == "" {
 		return nil, errors.New("invalid response")

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -291,7 +291,7 @@ func (c *backyardsCLI) withHealthCheck(ep endpoint.Endpoint) (endpoint.Endpoint,
 	client.RetryMax = 5
 	client.Logger = hclog.NewNullLogger()
 	level := hclog.Info
-	if viper.GetBool("output.verbose") {
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		level = hclog.Debug
 	}
 	client.Logger = hclog.New(&hclog.LoggerOptions{

--- a/pkg/cli/util.go
+++ b/pkg/cli/util.go
@@ -78,7 +78,7 @@ func getValidatedRawConfig() (*api.Config, error) {
 	}
 
 	if len(config.Clusters) == 0 {
-		return nil, errors.New("kubeconfig is invalid, no clusters defined")
+		return nil, errors.New("kubeconfig is not specified or invalid")
 	}
 
 	var ok bool


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- Rationalize install and uninstall flags by removing `--<install/uninstall>-<$component>` flags in favour of doing component install uninstall with the components' own commands.
- Login can happen concurrently when doing an `install -a --run-demo` so it has to be protected with a mutex to stay safe
- Improve final error handler to be less verbose for the end user, but show trace and details if requested explicitly with `-v`
- Improve `version` command error handling
