### PR TITLE
Rename global --namespace and -n flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Components commands:
 
 Flags:
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -100,7 +101,6 @@ Flags:
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards.md
+++ b/cmd/docs/backyards.md
@@ -10,6 +10,7 @@ Install and manage Backyards
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -19,7 +20,6 @@ Install and manage Backyards
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_canary.md
+++ b/cmd/docs/backyards_canary.md
@@ -16,6 +16,7 @@ Install and manage canary feature
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Install and manage canary feature
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_canary_install.md
+++ b/cmd/docs/backyards_canary_install.md
@@ -39,6 +39,7 @@ backyards canary install [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -47,7 +48,6 @@ backyards canary install [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_canary_uninstall.md
+++ b/cmd/docs/backyards_canary_uninstall.md
@@ -38,6 +38,7 @@ backyards canary uninstall [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -46,7 +47,6 @@ backyards canary uninstall [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_cert-manager.md
+++ b/cmd/docs/backyards_cert-manager.md
@@ -16,6 +16,7 @@ Install and manage cert-manager
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Install and manage cert-manager
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_cert-manager_install.md
+++ b/cmd/docs/backyards_cert-manager_install.md
@@ -32,6 +32,7 @@ backyards cert-manager install [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -40,7 +41,6 @@ backyards cert-manager install [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_cert-manager_uninstall.md
+++ b/cmd/docs/backyards_cert-manager_uninstall.md
@@ -36,6 +36,7 @@ backyards cert-manager uninstall [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -44,7 +45,6 @@ backyards cert-manager uninstall [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_config.md
+++ b/cmd/docs/backyards_config.md
@@ -16,6 +16,7 @@ View and manage persistent configuration
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ View and manage persistent configuration
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_config_delete.md
+++ b/cmd/docs/backyards_config_delete.md
@@ -20,6 +20,7 @@ backyards config delete [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -28,7 +29,6 @@ backyards config delete [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_config_edit.md
+++ b/cmd/docs/backyards_config_edit.md
@@ -20,6 +20,7 @@ backyards config edit [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -28,7 +29,6 @@ backyards config edit [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_config_view.md
+++ b/cmd/docs/backyards_config_view.md
@@ -20,6 +20,7 @@ backyards config view [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -28,7 +29,6 @@ backyards config view [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_dashboard.md
+++ b/cmd/docs/backyards_dashboard.md
@@ -20,6 +20,7 @@ backyards dashboard [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -28,7 +29,6 @@ backyards dashboard [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_demoapp.md
+++ b/cmd/docs/backyards_demoapp.md
@@ -17,6 +17,7 @@ Install and manage demo application
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -25,7 +26,6 @@ Install and manage demo application
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_demoapp_install.md
+++ b/cmd/docs/backyards_demoapp_install.md
@@ -37,6 +37,7 @@ backyards demoapp install [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -46,7 +47,6 @@ backyards demoapp install [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_demoapp_load.md
+++ b/cmd/docs/backyards_demoapp_load.md
@@ -22,6 +22,7 @@ backyards demoapp load [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -31,7 +32,6 @@ backyards demoapp load [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_demoapp_uninstall.md
+++ b/cmd/docs/backyards_demoapp_uninstall.md
@@ -34,6 +34,7 @@ backyards demoapp uninstall [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -43,7 +44,6 @@ backyards demoapp uninstall [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_graph.md
+++ b/cmd/docs/backyards_graph.md
@@ -24,6 +24,7 @@ backyards graph [[--service=]namespace/servicename] [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -32,7 +33,6 @@ backyards graph [[--service=]namespace/servicename] [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_install.md
+++ b/cmd/docs/backyards_install.md
@@ -44,6 +44,7 @@ backyards install [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -52,7 +53,6 @@ backyards install [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_istio.md
+++ b/cmd/docs/backyards_istio.md
@@ -16,6 +16,7 @@ Install and manage Istio
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Install and manage Istio
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_istio_cluster.md
+++ b/cmd/docs/backyards_istio_cluster.md
@@ -16,6 +16,7 @@ Manage Istio mesh member clusters
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)

--- a/cmd/docs/backyards_istio_cluster_attach.md
+++ b/cmd/docs/backyards_istio_cluster_attach.md
@@ -21,6 +21,7 @@ backyards istio cluster attach [path-to-kubeconfig] [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)

--- a/cmd/docs/backyards_istio_cluster_detach.md
+++ b/cmd/docs/backyards_istio_cluster_detach.md
@@ -20,6 +20,7 @@ backyards istio cluster detach [name] [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)

--- a/cmd/docs/backyards_istio_cluster_status.md
+++ b/cmd/docs/backyards_istio_cluster_status.md
@@ -20,6 +20,7 @@ backyards istio cluster status [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)

--- a/cmd/docs/backyards_istio_install.md
+++ b/cmd/docs/backyards_istio_install.md
@@ -39,6 +39,7 @@ backyards istio install [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)

--- a/cmd/docs/backyards_istio_outbound-traffic-policy.md
+++ b/cmd/docs/backyards_istio_outbound-traffic-policy.md
@@ -20,6 +20,7 @@ backyards istio outbound-traffic-policy [allowed|restricted] [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)

--- a/cmd/docs/backyards_istio_overview.md
+++ b/cmd/docs/backyards_istio_overview.md
@@ -21,6 +21,7 @@ backyards istio overview [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)

--- a/cmd/docs/backyards_istio_uninstall.md
+++ b/cmd/docs/backyards_istio_uninstall.md
@@ -35,6 +35,7 @@ backyards istio uninstall [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)

--- a/cmd/docs/backyards_license.md
+++ b/cmd/docs/backyards_license.md
@@ -20,6 +20,7 @@ backyards license [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -28,7 +29,6 @@ backyards license [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_login.md
+++ b/cmd/docs/backyards_login.md
@@ -20,6 +20,7 @@ backyards login [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -28,7 +29,6 @@ backyards login [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_mtls.md
+++ b/cmd/docs/backyards_mtls.md
@@ -16,6 +16,7 @@ Manage mTLS policy related configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage mTLS policy related configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_mtls_allow.md
+++ b/cmd/docs/backyards_mtls_allow.md
@@ -23,6 +23,7 @@ backyards mtls allow [[--resource=]mesh|namespace|namespace/servicename[:[portna
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -31,7 +32,6 @@ backyards mtls allow [[--resource=]mesh|namespace|namespace/servicename[:[portna
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_mtls_disable.md
+++ b/cmd/docs/backyards_mtls_disable.md
@@ -23,6 +23,7 @@ backyards mtls disable [[--resource=]namespace|namespace/servicename[:[portname|
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -31,7 +32,6 @@ backyards mtls disable [[--resource=]namespace|namespace/servicename[:[portname|
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_mtls_get.md
+++ b/cmd/docs/backyards_mtls_get.md
@@ -21,6 +21,7 @@ backyards mtls get [[--resource=]mesh|namespace|namespace/servicename] [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -29,7 +30,6 @@ backyards mtls get [[--resource=]mesh|namespace|namespace/servicename] [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_mtls_require.md
+++ b/cmd/docs/backyards_mtls_require.md
@@ -23,6 +23,7 @@ backyards mtls require [[--resource=]mesh|namespace|namespace/servicename[:[port
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -31,7 +32,6 @@ backyards mtls require [[--resource=]mesh|namespace|namespace/servicename[:[port
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_mtls_unset.md
+++ b/cmd/docs/backyards_mtls_unset.md
@@ -23,6 +23,7 @@ backyards mtls unset [[--resource=]namespace|namespace/servicename[:[portname|po
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -31,7 +32,6 @@ backyards mtls unset [[--resource=]namespace|namespace/servicename[:[portname|po
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing.md
+++ b/cmd/docs/backyards_routing.md
@@ -16,6 +16,7 @@ Manage service routing configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage service routing configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_circuit-breaker.md
+++ b/cmd/docs/backyards_routing_circuit-breaker.md
@@ -16,6 +16,7 @@ Manage circuit-breaker configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage circuit-breaker configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_circuit-breaker_delete.md
+++ b/cmd/docs/backyards_routing_circuit-breaker_delete.md
@@ -21,6 +21,7 @@ backyards routing circuit-breaker delete [[--service=]namespace/servicename] [fl
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -29,7 +30,6 @@ backyards routing circuit-breaker delete [[--service=]namespace/servicename] [fl
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_circuit-breaker_get.md
+++ b/cmd/docs/backyards_routing_circuit-breaker_get.md
@@ -21,6 +21,7 @@ backyards routing circuit-breaker get [[--service=]namespace/servicename] [flags
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -29,7 +30,6 @@ backyards routing circuit-breaker get [[--service=]namespace/servicename] [flags
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_circuit-breaker_graph.md
+++ b/cmd/docs/backyards_routing_circuit-breaker_graph.md
@@ -24,6 +24,7 @@ backyards routing circuit-breaker graph [[--service=]namespace/servicename] [fla
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -32,7 +33,6 @@ backyards routing circuit-breaker graph [[--service=]namespace/servicename] [fla
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_circuit-breaker_set.md
+++ b/cmd/docs/backyards_routing_circuit-breaker_set.md
@@ -31,6 +31,7 @@ backyards routing circuit-breaker set [[--service=]namespace/servicename] [[--ve
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -39,7 +40,6 @@ backyards routing circuit-breaker set [[--service=]namespace/servicename] [[--ve
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_fault-injection.md
+++ b/cmd/docs/backyards_routing_fault-injection.md
@@ -16,6 +16,7 @@ Manage fault injection configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage fault injection configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_fault-injection_delete.md
+++ b/cmd/docs/backyards_routing_fault-injection_delete.md
@@ -22,6 +22,7 @@ backyards routing fault-injection delete [[--service=]namespace/servicename] [-m
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -30,7 +31,6 @@ backyards routing fault-injection delete [[--service=]namespace/servicename] [-m
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_fault-injection_get.md
+++ b/cmd/docs/backyards_routing_fault-injection_get.md
@@ -23,6 +23,7 @@ backyards routing fault-injection get [[--service=]namespace/servicename] [[--ma
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -31,7 +32,6 @@ backyards routing fault-injection get [[--service=]namespace/servicename] [[--ma
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_fault-injection_set.md
+++ b/cmd/docs/backyards_routing_fault-injection_set.md
@@ -26,6 +26,7 @@ backyards routing fault-injection set [[--service=]namespace/servicename] [[--ma
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -34,7 +35,6 @@ backyards routing fault-injection set [[--service=]namespace/servicename] [[--ma
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_mirror.md
+++ b/cmd/docs/backyards_routing_mirror.md
@@ -16,6 +16,7 @@ Manage http route mirror configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage http route mirror configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_mirror_delete.md
+++ b/cmd/docs/backyards_routing_mirror_delete.md
@@ -22,6 +22,7 @@ backyards routing mirror delete [[--service=]namespace/servicename] [-m|--match 
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -30,7 +31,6 @@ backyards routing mirror delete [[--service=]namespace/servicename] [-m|--match 
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_mirror_get.md
+++ b/cmd/docs/backyards_routing_mirror_get.md
@@ -23,6 +23,7 @@ backyards routing mirror get [[--service=]namespace/servicename] [[--match=]fiel
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -31,7 +32,6 @@ backyards routing mirror get [[--service=]namespace/servicename] [[--match=]fiel
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_mirror_set.md
+++ b/cmd/docs/backyards_routing_mirror_set.md
@@ -25,6 +25,7 @@ backyards routing mirror set [[--service=]namespace/servicename] [[--match=]fiel
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -33,7 +34,6 @@ backyards routing mirror set [[--service=]namespace/servicename] [[--match=]fiel
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_rewrite.md
+++ b/cmd/docs/backyards_routing_rewrite.md
@@ -16,6 +16,7 @@ Manage http route rewrite configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage http route rewrite configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_rewrite_delete.md
+++ b/cmd/docs/backyards_routing_rewrite_delete.md
@@ -22,6 +22,7 @@ backyards routing rewrite delete [[--service=]namespace/servicename] [-m|--match
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -30,7 +31,6 @@ backyards routing rewrite delete [[--service=]namespace/servicename] [-m|--match
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_rewrite_get.md
+++ b/cmd/docs/backyards_routing_rewrite_get.md
@@ -23,6 +23,7 @@ backyards routing rewrite get [[--service=]namespace/servicename] [[--match=]fie
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -31,7 +32,6 @@ backyards routing rewrite get [[--service=]namespace/servicename] [[--match=]fie
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_rewrite_set.md
+++ b/cmd/docs/backyards_routing_rewrite_set.md
@@ -24,6 +24,7 @@ backyards routing rewrite set [[--service=]namespace/servicename] [[--match=]fie
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -32,7 +33,6 @@ backyards routing rewrite set [[--service=]namespace/servicename] [[--match=]fie
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_route.md
+++ b/cmd/docs/backyards_routing_route.md
@@ -16,6 +16,7 @@ Manage route configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage route configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_route_delete.md
+++ b/cmd/docs/backyards_routing_route_delete.md
@@ -22,6 +22,7 @@ backyards routing route delete [[--service=]namespace/servicename] [[--match=]fi
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -30,7 +31,6 @@ backyards routing route delete [[--service=]namespace/servicename] [[--match=]fi
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_route_get.md
+++ b/cmd/docs/backyards_routing_route_get.md
@@ -23,6 +23,7 @@ backyards routing route get [[--service=]namespace/servicename] [[--match=]field
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -31,7 +32,6 @@ backyards routing route get [[--service=]namespace/servicename] [[--match=]field
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_route_set.md
+++ b/cmd/docs/backyards_routing_route_set.md
@@ -30,6 +30,7 @@ backyards routing route set [[--service=]namespace/servicename] [[--match=]field
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -38,7 +39,6 @@ backyards routing route set [[--service=]namespace/servicename] [[--match=]field
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_traffic-shifting.md
+++ b/cmd/docs/backyards_routing_traffic-shifting.md
@@ -16,6 +16,7 @@ Manage traffic-shifting configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage traffic-shifting configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_traffic-shifting_delete.md
+++ b/cmd/docs/backyards_routing_traffic-shifting_delete.md
@@ -22,6 +22,7 @@ backyards routing traffic-shifting delete [[--service=]namespace/servicename] [f
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -30,7 +31,6 @@ backyards routing traffic-shifting delete [[--service=]namespace/servicename] [f
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_traffic-shifting_get.md
+++ b/cmd/docs/backyards_routing_traffic-shifting_get.md
@@ -22,6 +22,7 @@ backyards routing traffic-shifting get [[--service=]namespace/servicename] [[--m
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -30,7 +31,6 @@ backyards routing traffic-shifting get [[--service=]namespace/servicename] [[--m
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_routing_traffic-shifting_set.md
+++ b/cmd/docs/backyards_routing_traffic-shifting_set.md
@@ -23,6 +23,7 @@ backyards routing traffic-shifting set [[--service=]namespace/servicename] [[--m
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -31,7 +32,6 @@ backyards routing traffic-shifting set [[--service=]namespace/servicename] [[--m
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_sidecar-proxy.md
+++ b/cmd/docs/backyards_sidecar-proxy.md
@@ -16,6 +16,7 @@ Manage sidecar-proxy related configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage sidecar-proxy related configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_sidecar-proxy_auto-inject.md
+++ b/cmd/docs/backyards_sidecar-proxy_auto-inject.md
@@ -16,6 +16,7 @@ Manage auto-injection configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage auto-injection configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_sidecar-proxy_auto-inject_off.md
+++ b/cmd/docs/backyards_sidecar-proxy_auto-inject_off.md
@@ -20,6 +20,7 @@ backyards sidecar-proxy auto-inject off [[--namespace=]name] [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -28,7 +29,6 @@ backyards sidecar-proxy auto-inject off [[--namespace=]name] [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_sidecar-proxy_auto-inject_on.md
+++ b/cmd/docs/backyards_sidecar-proxy_auto-inject_on.md
@@ -20,6 +20,7 @@ backyards sidecar-proxy auto-inject on [[--namespace=]name] [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -28,7 +29,6 @@ backyards sidecar-proxy auto-inject on [[--namespace=]name] [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_sidecar-proxy_egress.md
+++ b/cmd/docs/backyards_sidecar-proxy_egress.md
@@ -16,6 +16,7 @@ Manage sidecar egress configurations
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -24,7 +25,6 @@ Manage sidecar egress configurations
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_sidecar-proxy_egress_delete.md
+++ b/cmd/docs/backyards_sidecar-proxy_egress_delete.md
@@ -22,6 +22,7 @@ backyards sidecar-proxy egress delete [--namespace] namespace [--workload name] 
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -30,7 +31,6 @@ backyards sidecar-proxy egress delete [--namespace] namespace [--workload name] 
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_sidecar-proxy_egress_get.md
+++ b/cmd/docs/backyards_sidecar-proxy_egress_get.md
@@ -21,6 +21,7 @@ backyards sidecar-proxy egress get [--namespace] namespace [--workload name] [fl
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -29,7 +30,6 @@ backyards sidecar-proxy egress get [--namespace] namespace [--workload name] [fl
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_sidecar-proxy_egress_recommend.md
+++ b/cmd/docs/backyards_sidecar-proxy_egress_recommend.md
@@ -24,6 +24,7 @@ backyards sidecar-proxy egress recommend [--namespace] namespace [--workload nam
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -32,7 +33,6 @@ backyards sidecar-proxy egress recommend [--namespace] namespace [--workload nam
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_sidecar-proxy_egress_set.md
+++ b/cmd/docs/backyards_sidecar-proxy_egress_set.md
@@ -24,6 +24,7 @@ backyards sidecar-proxy egress set [--namespace] namespace [--workload name] [--
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -32,7 +33,6 @@ backyards sidecar-proxy egress set [--namespace] namespace [--workload name] [--
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_tap.md
+++ b/cmd/docs/backyards_tap.md
@@ -46,6 +46,7 @@ backyards tap [[ns|workload|pod]/resource-name] [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -54,7 +55,6 @@ backyards tap [[ns|workload|pod]/resource-name] [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_uninstall.md
+++ b/cmd/docs/backyards_uninstall.md
@@ -37,6 +37,7 @@ backyards uninstall [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -45,7 +46,6 @@ backyards uninstall [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/

--- a/cmd/docs/backyards_version.md
+++ b/cmd/docs/backyards_version.md
@@ -22,6 +22,7 @@ backyards version [flags]
 
 ```
       --accept-license                  Accept the license: https://banzaicloud.com/docs/backyards/evaluation-license
+      --backyards-namespace string      Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --base-url string                 Custom Backyards base URL (uses port forwarding or proxying if empty)
       --cacert string                   The CA to use for verifying Backyards' server certificate
       --color                           use colors on non-tty outputs (default true)
@@ -30,7 +31,6 @@ backyards version [flags]
       --interactive                     ask questions interactively even if stdin or stdout is non-tty
   -c, --kubeconfig string               path to the kubeconfig file to use for CLI requests
   -p, --local-port int                  Use this local port for port forwarding / proxying to Backyards (when set to 0, a random port will be used) (default -1)
-  -n, --namespace string                Namespace in which Backyards is installed [$BACKYARDS_NAMESPACE] (default "backyards-system")
       --non-interactive                 never ask questions interactively
   -o, --output string                   output format (table|yaml|json) (default "table")
       --persistent-config-file string   Backyards persistent config file to use instead of the default at ~/.banzai/backyards/


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| Related tickets |
| License         | Apache 2.0

### What's in this PR?
Rename global --namespace and -n flags

### Why?
Currently, it's not always possible to use the global --namespace and -n flags.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] User guide and development docs updated (if needed)

### Details
The --namespace and -n flags are defined in some of the subcommands and
also as a global flag. These two definitions are incompatible.
For example, when running the `sidecar-proxy egress` subcommand, it's
not possible to set the namespace where backyards is installed.

This commit deprecates the global --namespace and -n flags and
introduces the new global --backyards-namespace flag (without a
shorthand form).

Using the --namespace and -n flags as global flags is still possible
when a subcommand does not override these. In this case the following
message will be printed:

    Flag shorthand -n has been deprecated, please use --backyards-namespace instead
    Flag --namespace has been deprecated, please use --backyards-namespace instead

Also regenerated the docs and updated the `backyards --help` output in
README.md
