### PR TITLE
Fix create PR GH action pattern to only run on actual release branches

### DIFF
--- a/.github/workflows/create_pull_request.yaml
+++ b/.github/workflows/create_pull_request.yaml
@@ -2,7 +2,7 @@ name: Create pull request from release branch to master
 on:
   push:
     branches:
-      - release-*
+      - release-[0-9]+.[0-9]+
 jobs:
   create_pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

A branch push like `release-1.2-xyz` could trigger a GH action which should not be the case.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (on separate repo)
